### PR TITLE
Update Jenkins to upload a universal wheel to pypi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ addons:
 before_install:
   # Uninstall default pytest because it is old
   - pip uninstall -y pytest
+  # Install the local cnx-transforms
+  - pip install .
   - pip install -r requirements/lint.txt
   - pip install -r requirements/test.txt
   - flake8 cnxtransforms/ tests/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
       }
       steps {
         // Install git, run the python build, upload to pypi, and cleanup
-        sh "docker run --rm -e TWINE_USERNAME -e TWINE_PASSWORD -v ${WORKSPACE}:/src:rw --workdir /src python:2-slim /bin/bash -c \"apt-get update && apt-get install -y git && pip install -q twine && python setup.py bdist_wheel && twine upload dist/* && rm -rf dist build *.egg-info versioneer.pyc\""
+        sh "docker run --rm -e TWINE_USERNAME -e TWINE_PASSWORD -v ${WORKSPACE}:/src:rw --workdir /src python:2-slim /bin/bash -c \"apt-get update && apt-get install -y git && pip install -q twine && python setup.py bdist_wheel --universal && twine upload dist/* && rm -rf dist build *.egg-info versioneer.pyc\""
       }
     }
   }


### PR DESCRIPTION
By default, the wheel file is only for whatever version of python we use
to build the distribution.  We used python 2 so we only had a py2 wheel
for v1.0.0.  Add `--universal` to the `bdist_wheel` command to build a
wheel file for python 2 and 3.

Close #4