### PR TITLE
1985 Convert screenreader-table-description attribute to aria-label

### DIFF
--- a/cnxtransforms/xsl/cnxml-to-html5.xsl
+++ b/cnxtransforms/xsl/cnxml-to-html5.xsl
@@ -1753,6 +1753,13 @@
   <xsl:copy/>
 </xsl:template>
 
+<!-- Convert screenreader-table-description attribute into aria-label -->
+<xsl:template match="c:table/@screenreader-table-description">
+  <xsl:attribute name="aria-label">
+    <xsl:value-of select="."/>
+  </xsl:attribute>
+</xsl:template>
+
 <!-- Discarded attributes -->
 <xsl:template match="c:table/@pgwide"/>
 

--- a/cnxtransforms/xsl/cnxml-to-html5.xsl
+++ b/cnxtransforms/xsl/cnxml-to-html5.xsl
@@ -1753,11 +1753,9 @@
   <xsl:copy/>
 </xsl:template>
 
-<!-- Convert screenreader-table-description attribute into aria-label -->
-<xsl:template match="c:table/@screenreader-table-description">
-  <xsl:attribute name="aria-label">
-    <xsl:value-of select="."/>
-  </xsl:attribute>
+<!-- Copy the aria-label attribute -->
+<xsl:template match="c:table/@aria-label">
+  <xsl:copy/>
 </xsl:template>
 
 <!-- Discarded attributes -->

--- a/tests/cnxml/table.cnxml
+++ b/tests/cnxml/table.cnxml
@@ -3,7 +3,7 @@
  <title>Test Tables</title>
   <content>
     <section id="section-1">
-      <table id="report_card" pgwide="1" screenreader-table-description="" summary="The first column             lists each course. Each row in the second column             delineates a semester. The corresponding row in            the third column shows that semester's grade.              The footer tallies the student's average.">
+      <table id="report_card" pgwide="1" aria-label="" summary="The first column             lists each course. Each row in the second column             delineates a semester. The corresponding row in            the third column shows that semester's grade.              The footer tallies the student's average.">
         <title>Report card</title>
         <tgroup cols="3">
           <colspec colname="c1" colnum="1"/>

--- a/tests/cnxml/table.cnxml
+++ b/tests/cnxml/table.cnxml
@@ -3,7 +3,7 @@
  <title>Test Tables</title>
   <content>
     <section id="section-1">
-      <table id="report_card" pgwide="1" summary="The first column             lists each course. Each row in the second column             delineates a semester. The corresponding row in            the third column shows that semester's grade.              The footer tallies the student's average.">
+      <table id="report_card" pgwide="1" screenreader-table-description="" summary="The first column             lists each course. Each row in the second column             delineates a semester. The corresponding row in            the third column shows that semester's grade.              The footer tallies the student's average.">
         <title>Report card</title>
         <tgroup cols="3">
           <colspec colname="c1" colnum="1"/>

--- a/tests/cnxml/title.cnxml
+++ b/tests/cnxml/title.cnxml
@@ -44,7 +44,7 @@
 
     <section id="tabled-section">
 
-      <table id="tabled-section-table" summary="Table 1" screenreader-table-description="Board Member Community Types">
+      <table id="tabled-section-table" summary="Table 1" aria-label="Board Member Community Types">
         <title>
           <emphasis effect="italics">Board Member Community Types</emphasis>
         </title>

--- a/tests/cnxml/title.cnxml
+++ b/tests/cnxml/title.cnxml
@@ -44,7 +44,7 @@
 
     <section id="tabled-section">
 
-      <table id="tabled-section-table" summary="Table 1">
+      <table id="tabled-section-table" summary="Table 1" screenreader-table-description="Board Member Community Types">
         <title>
           <emphasis effect="italics">Board Member Community Types</emphasis>
         </title>

--- a/tests/snapshots/test_converters/test_diffs/table.xhtml
+++ b/tests/snapshots/test_converters/test_diffs/table.xhtml
@@ -4,7 +4,7 @@
 
 <body xmlns="http://www.w3.org/1999/xhtml" xmlns:c="http://cnx.rice.edu/cnxml" xmlns:md="http://cnx.rice.edu/mdml" xmlns:qml="http://cnx.rice.edu/qml/1.0" xmlns:mod="http://cnx.rice.edu/#moduleIds" xmlns:bib="http://bibtexml.sf.net/" xmlns:data="http://www.w3.org/TR/html5/dom.html#custom-data-attribute" xmlns:epub="http://www.idpf.org/2007/ops"><div data-type="document-title">Test Tables</div>
     <section data-depth="1" id="section-1">
-      <table id="report_card" summary="The first column             lists each course. Each row in the second column             delineates a semester. The corresponding row in            the third column shows that semester's grade.              The footer tallies the student's average."><caption><span data-type="title">Report card</span></caption><thead>
+      <table id="report_card" aria-label="" summary="The first column             lists each course. Each row in the second column             delineates a semester. The corresponding row in            the third column shows that semester's grade.              The footer tallies the student's average."><caption><span data-type="title">Report card</span></caption><thead>
             <tr>
               <th data-align="center" data-valign="top">Course</th>
               <th class="gray-background">Semester</th>

--- a/tests/snapshots/test_converters/test_diffs/title.xhtml
+++ b/tests/snapshots/test_converters/test_diffs/title.xhtml
@@ -38,7 +38,7 @@
 
     <section data-depth="1" id="tabled-section">
 
-      <table id="tabled-section-table" summary="Table 1"><caption><span data-type="title">
+      <table id="tabled-section-table" summary="Table 1" aria-label="Board Member Community Types"><caption><span data-type="title">
           <em data-effect="italics">Board Member Community Types</em>
         </span></caption><tbody>
             <tr>


### PR DESCRIPTION
- [ ] openstax/ce#1985

~Convert the, soon to be introduced, screenreader-table-description attribute to aria-label for accessibility. For now, the summary attribute will still be copied.~

- Make table summary optional
- Add optional table attribute aria-label 